### PR TITLE
Include internal margins and borders within widths and heights

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -12,14 +12,15 @@ html {
     width: 1160px; /* Fixed width for better layout control */
     margin: auto; /* Centering the page */
 }
-
+* {
+    box-sizing: border-box;
+}
 h1,h2,h3,h4,h5,h6 {
     font-family: 'Lato', sans-serif;
     margin: 0;
     padding: 0;
     font-weight: bold; /* Ensure headings are bold */
 }
-
 body {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
The CSS has been updated to use `box-sizing: border-box`, ensuring that internal margins and borders are included within the specified widths and heights of the page.

Fixes #18